### PR TITLE
fix for GHC 7.8.2

### DIFF
--- a/samtools/src/Bio/SamTools/LowLevel.chs
+++ b/samtools/src/Bio/SamTools/LowLevel.chs
@@ -42,6 +42,7 @@ module Bio.SamTools.LowLevel ( TamFilePtr
                              )
 where
 
+import System.IO.Unsafe (unsafePerformIO)
 import Foreign hiding (Word)
 import Foreign.C
 


### PR DESCRIPTION
I was having trouble building this module on GHC 7.8.2. I got this error message:

```
Building samtools-0.2.2...
Preprocessing library samtools-0.2.2...
[1 of 6] Compiling Bio.SamTools.LowLevel ( dist/build/Bio/SamTools/LowLevel.hs, dist/build/Bio/SamTools/LowLevel.o )

src/Bio/SamTools/LowLevel.chs:202:3:
    Not in scope: ‘unsafePerformIO’
```

I managed to fix the problem by importing unsafePerformIO in LowLevel.chs.
