### PR TITLE
Fix compilation issues on Mac

### DIFF
--- a/samtools/src/Bio/SamTools/LowLevel.chs
+++ b/samtools/src/Bio/SamTools/LowLevel.chs
@@ -58,6 +58,9 @@ import qualified Data.ByteString.Char8 as BS
 #define __AVAILABILITY__
 #define __OSX_AVAILABLE_STARTING(_mac, _iphone)
 #define __OSX_AVAILABLE_BUT_DEPRECATED(_macIntro, _macDep, _iphoneIntro, _iphoneDep) 
+#define __OSX_AVAILABLE_BUT_DEPRECATED_MSG(_macIntro, _macDep, _iphoneIntro, _iphoneDep, _warn_string) 
+#define __WATCHOS_PROHIBITED
+#define __TVOS_PROHIBITED
 #endif
 
 #include "faidx.h"


### PR DESCRIPTION
Search me for why, but c2hs was choking on OSX availability macros, and this
fixed it.

I was getting errors like:
```
-> % cabal build 
Building samtools-0.2.4.1...
Preprocessing library samtools-0.2.4.1...
c2hs: C header contains errors:

/usr/include/stdlib.h:177: (column 47) [ERROR]  >>> Syntax error !
  The symbol `__OSX_AVAILABLE_BUT_DEPRECATED_MSG' does not fit here.
```
in the basic samtools package.
So I just `#define`d them away; I'm not sure if this is the right thing to do, but it made it build.

FWIW, I'm on OS X 10.11 El Capitan.
```
-> % cabal --version
cabal-install version 1.22.6.0
using version 1.22.4.0 of the Cabal library 
-> % ghc --version
The Glorious Glasgow Haskell Compilation System, version 7.10.3
-> % c2hs --version
C->Haskell Compiler, version 0.27.1 Eternal Sunshine, 29 November 2015
  build platform is "x86_64-darwin" <1, True, True, 1>
```