### PR TITLE
Documentation fixes

### DIFF
--- a/samtools/src/Bio/SamTools/Bam.hs
+++ b/samtools/src/Bio/SamTools/Bam.hs
@@ -422,7 +422,7 @@ withTamInFileWithIndex filename indexname = bracket (openTamInFileWithIndex file
 withBamInFile :: FilePath -> (InHandle -> IO a) -> IO a
 withBamInFile filename = bracket (openBamInFile filename) closeInHandle
 
--- | Reads one alignment from an input handle, or returns @Nothing@ for end-of-file
+-- | Read one alignment from an input handle, or returns @Nothing@ for end-of-file
 get1 :: InHandle -> IO (Maybe Bam1)
 get1 inh = withMVar (samfile inh) $ \fsam -> do
   b <- bamInit1
@@ -435,7 +435,7 @@ get1 inh = withMVar (samfile inh) $ \fsam -> do
     else do bptr <- newForeignPtr bamDestroy1Ptr b
             return . Just $ Bam1 { ptrBam1 = bptr, header = inHeader inh }
 
--- | Read a BAM file as a lazy strem of 'Bam1' records.
+-- | Read a BAM file as a lazy stream of 'Bam1' records.
 readBams :: FilePath -> IO [Bam1]
 readBams = openBamInFile >=> getBams 
   where
@@ -478,7 +478,7 @@ withTamOutFile filename hdr = bracket (openTamOutFile filename hdr) closeOutHand
 withBamOutFile :: FilePath -> Header -> (OutHandle -> IO a) -> IO a
 withBamOutFile filename hdr = bracket (openBamOutFile filename hdr) closeOutHandle
 
--- | Writes one alignment to an input handle.
+-- | Write one alignment to an output handle.
 -- 
 -- There is no validation that the target sequence set of the output
 -- handle matches the target sequence set of the alignment.

--- a/samtools/src/Bio/SamTools/LowLevel.chs
+++ b/samtools/src/Bio/SamTools/LowLevel.chs
@@ -58,6 +58,9 @@ import qualified Data.ByteString.Char8 as BS
 #define __AVAILABILITY__
 #define __OSX_AVAILABLE_STARTING(_mac, _iphone)
 #define __OSX_AVAILABLE_BUT_DEPRECATED(_macIntro, _macDep, _iphoneIntro, _iphoneDep) 
+#define __OSX_AVAILABLE_BUT_DEPRECATED_MSG(_macIntro, _macDep, _iphoneIntro, _iphoneDep, _warn_string) 
+#define __WATCHOS_PROHIBITED
+#define __TVOS_PROHIBITED
 #endif
 
 #include "faidx.h"


### PR DESCRIPTION
I noticed some typos and inconsistent usage in the documentation for the samtools package.